### PR TITLE
fix(main): Fix logic to allow for optional one-time prekeys

### DIFF
--- a/serialize/ProtoBufferSerializer.go
+++ b/serialize/ProtoBufferSerializer.go
@@ -112,7 +112,7 @@ func (j *ProtoBufPreKeySignalMessageSerializer) Serialize(signalMessage *protoco
 		Message:        signalMessage.Message,
 	}
 
-	if !signalMessage.PreKeyID.IsEmpty {
+	if signalMessage.PreKeyID != nil && !signalMessage.PreKeyID.IsEmpty {
 		preKeyMessage.PreKeyId = &signalMessage.PreKeyID.Value
 	}
 


### PR DESCRIPTION
This will patch the libsignal go library such that sessions can be established without a one-time prekey (otherwise it will panic and fail)